### PR TITLE
fix: add postgresql env

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -29,6 +29,8 @@ spec:
             value: "/swagger-ui"
           - name: SPRINGDOC_SWAGGERUI_URL
             value: "/v1/api-docs"
+          - name: SPRINGDOC_API-DOCS_PATH
+            value: "/v1/api-docs"
           - name: SERVER_SERVLET_CONTEXT_PATH
             value: "/api/"
           - name: SPRING_JPA_HIBERNATE_DIALECT

--- a/api.yaml
+++ b/api.yaml
@@ -31,6 +31,12 @@ spec:
             value: "/v1/api-docs"
           - name: SERVER_SERVLET_CONTEXT_PATH
             value: "/api/"
+          - name: SPRING_JPA_HIBERNATE_DIALECT
+            value: "org.hibernate.dialect.PostgreSQLDialect"
+          - name: SPRING_DATASOURCE_DRIVER_CLASS_NAME
+            value: "org.postgresql.Driver"
+          
+        
         ports:
           - containerPort: 8080
 


### PR DESCRIPTION
fix: add postgresql env

The application was configured to use the H2 JDBC environment in the local application.yml.
When Tomcat runs, an error occurs:

```sh
java.lang.RuntimeException: Driver org.h2.Driver claims to not accept jdbcUrl, jdbc:postgresql://postgresql.default.svc.cluster.local:5432/caring_note
	at com.zaxxer.hikari.util.DriverDataSource.<init>(DriverDataSource.java:109)
```

To resolve this, the PostgreSQL JDBC environment has been added to the api.yaml file.

fix: add Swagger env
set api-docs path
