### PR TITLE
feat: add readiness probe to deployment configuration

### DIFF
--- a/staging/api.yaml
+++ b/staging/api.yaml
@@ -63,6 +63,15 @@ spec:
           ports:
             - containerPort: 8080
 
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 3
+
+
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
deployment에 readinessProbe 추가.
deployment에 rollingupdate를 적용했지만, readinessProbe가 없어서, 스프링부트가 시작되는 동안 500에러가 발생

stage에서 테스트 해보고, main에 추가 예정